### PR TITLE
add relocating to home page function to logo

### DIFF
--- a/src/shared/Layout.js
+++ b/src/shared/Layout.js
@@ -15,6 +15,9 @@ const Header = styled.div`
 const Logo = styled.h1`
   font-size: 30px;
   font-weight: 800;
+  :hover {
+    cursor: pointer;
+  }
 `;
 
 const WelcomeMsg = styled.span`
@@ -30,7 +33,7 @@ const Layout = React.forwardRef((props, ref) => {
     return (
       <>
         <Header ref={ref}>
-          <Logo>🛶 Onpiece</Logo>
+          <Logo onClick={() => window.location.replace("/")}>🛶 Onpiece</Logo>
           <div>
             <WelcomeMsg>유진님 환영합니다.</WelcomeMsg>
             <Button type="accent" text={`LOGOUT`} />


### PR DESCRIPTION
# 로고에 홈페이지 이동 기능 구현
## 구현 상세
* 로고에 `onClick` 이벤트를 사용해 홈페이지 이동 기능 추가. 이 때, `Layout` 컴포넌트는 Routes 외부에 있기 때문에 `window.location.replace()`를 사용.