### PR TITLE
fix home page to display posts flex start

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -6,10 +6,53 @@ import Progressbar from "./Progressbar";
 import dateTimeParser from "../tools/dateTimeParser";
 import { useNavigate } from "react-router-dom";
 
+function Post({ width = 18, post }) {
+  const navigate = useNavigate();
+  return (
+    <Wrapper width={`${width}%`} onClick={() => navigate(`/post/${post.id}`)}>
+      <Title>{post.title}</Title>
+      <SubTitle>👨‍✈{post.nickname} 선장님이 이끄는 스터디</SubTitle>
+      <TagBox>
+        <Tag type="level" text={post.level}></Tag>
+      </TagBox>
+      <TagBox>
+        {post.category.map((v) => (
+          <Tag key={v} type="category" text={v}></Tag>
+        ))}
+      </TagBox>
+      <InfoBox>
+        <Label>모집기간</Label>
+        <Info>{`${dateTimeParser(post.recruitmentEndDay)} 까지`}</Info>
+      </InfoBox>
+      <InfoBox>
+        <Label>스터디기간</Label>
+        <Info>
+          {post.startDay} - {post.endDay}
+        </Info>
+      </InfoBox>
+      <InfoBox>
+        <Label>스터디시간</Label>
+        <Info>
+          {post.startTime} - {post.endTime}
+        </Info>
+      </InfoBox>
+      <InfoBox>
+        <Label>모집인원</Label>
+        <Info>
+          <Progressbar
+            denominator={post.headCount}
+            numerator={post.applicants.length}
+          ></Progressbar>
+        </Info>
+      </InfoBox>
+    </Wrapper>
+  );
+}
+
 const Wrapper = styled.div`
   width: ${(props) => props.width};
   padding: 2%;
-  margin-top: 20px;
+  margin: 20px 1.3%;
   float: left;
   display: flex;
   flex-direction: column;
@@ -51,48 +94,5 @@ const Info = styled.div`
   font-size: 14px;
   width: 68%;
 `;
-
-function Post({ width = 20, post }) {
-  const navigate = useNavigate();
-  return (
-    <Wrapper  width={`${width}%`} onClick={() => navigate(`/post/${post.id}`)}>
-      <Title>{post.title}</Title>
-      <SubTitle>👨‍✈{post.nickname} 선장님이 이끄는 스터디</SubTitle>
-      <TagBox>
-        <Tag type="level" text={post.level}></Tag>
-      </TagBox>
-      <TagBox>
-        {post.category.map((v) => (
-          <Tag key={v} type="category" text={v}></Tag>
-        ))}
-      </TagBox>
-      <InfoBox>
-        <Label>모집기간</Label>
-        <Info>{`${dateTimeParser(post.recruitmentEndDay)} 까지`}</Info>
-      </InfoBox>
-      <InfoBox>
-        <Label>스터디기간</Label>
-        <Info>
-          {post.startDay} - {post.endDay}
-        </Info>
-      </InfoBox>
-      <InfoBox>
-        <Label>스터디시간</Label>
-        <Info>
-          {post.startTime} - {post.endTime}
-        </Info>
-      </InfoBox>
-      <InfoBox>
-        <Label>모집인원</Label>
-        <Info>
-          <Progressbar
-            denominator={post.headCount}
-            numerator={post.applicants.length}
-          ></Progressbar>
-        </Info>
-      </InfoBox>
-    </Wrapper>
-  );
-}
 
 export default Post;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -5,44 +5,6 @@ import styled from "styled-components";
 import Button from "../components/Button";
 import Post from "../components/Post";
 
-const Wrapper = styled.div`
-  width: 100%;
-  min-height: ${(props) => props.minHeight};
-`;
-
-const Content = styled.div`
-  padding: 40px;
-`;
-
-const ContentHeader = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-const Title = styled.h1`
-  font-size: 20px;
-  font-weight: 600;
-`;
-
-const PostList = styled.div`
-  padding: 20px 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  flex-wrap: wrap;
-`;
-
-const InfoBox = styled.div`
-  width: 100%;
-  height: 100%;
-  line-height: ${(props) => props.lineHeight};
-  text-align: center;
-  color: white;
-  font-weight: 600;
-`;
-
 function Home({ minHeight }) {
   const posts = useSelector((store) => store.posts.posts);
   const [lineHeight, setLineHeight] = useState(0);
@@ -74,5 +36,42 @@ function Home({ minHeight }) {
     </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  width: 100%;
+  min-height: ${(props) => props.minHeight};
+`;
+
+const Content = styled.div`
+  padding: 40px;
+`;
+
+const ContentHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Title = styled.h1`
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+const PostList = styled.div`
+  padding: 20px 0;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+`;
+
+const InfoBox = styled.div`
+  width: 100%;
+  height: 100%;
+  line-height: ${(props) => props.lineHeight};
+  text-align: center;
+  color: white;
+  font-weight: 600;
+`;
 
 export default Home;


### PR DESCRIPTION
# `Home` 페이지 `Post` 정렬 수정
## 변경 전
`Post` 정렬이 `space-between`으로 되어있어, 개수가 적은 행에서는 개수가 꽉찬 행과 열 정렬이 맞지 않는 문제 발생.

## 변경 후
`Post` 정렬을 `flex-start`로 변경하고, `Post` 사이의 공백을 margin 값으로 고정해두어 행과 열이 맞도록 정렬이 됨.