### PR TITLE
add apply and see detail button on post component

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -5,11 +5,13 @@ import Tag from "./Tag";
 import Progressbar from "./Progressbar";
 import dateTimeParser from "../tools/dateTimeParser";
 import { useNavigate } from "react-router-dom";
+import Button from "./Button";
 
-function Post({ width = 18, post }) {
+function Post({ width = 18, post, isApplied = false }) {
   const navigate = useNavigate();
+
   return (
-    <Wrapper width={`${width}%`} onClick={() => navigate(`/post/${post.id}`)}>
+    <Wrapper width={`${width}%`}>
       <Title>{post.title}</Title>
       <SubTitle>👨‍✈{post.nickname} 선장님이 이끄는 스터디</SubTitle>
       <TagBox>
@@ -45,6 +47,21 @@ function Post({ width = 18, post }) {
           ></Progressbar>
         </Info>
       </InfoBox>
+      <BtnWrapper>
+        {isApplied ? (
+          <Button type="cancel" text="하차하기" />
+        ) : (
+          <Button
+            type="main"
+            text="탑승하기"
+            disabled={post.headCount === post.applicants.length}
+          />
+        )}
+        <Button
+          text="구경하기"
+          handler={() => navigate(`/post/${post.postId}`)}
+        />
+      </BtnWrapper>
     </Wrapper>
   );
 }
@@ -60,9 +77,6 @@ const Wrapper = styled.div`
   border: 2px solid ${(props) => props.theme.subColor};
   border-radius: 10px;
   background-color: white;
-  :hover {
-    cursor: pointer;
-  }
 `;
 
 const Title = styled.h2`
@@ -93,6 +107,14 @@ const Label = styled.span`
 const Info = styled.div`
   font-size: 14px;
   width: 68%;
+`;
+
+const BtnWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export default Post;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,11 +1,20 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
 import Button from "../components/Button";
 import Post from "../components/Post";
 
+import { __getAppliedStudies } from "../redux/modules/UserSlice";
+
 function Home({ minHeight }) {
+  const userId = useSelector((store) => store.user.id);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(__getAppliedStudies(userId));
+  }, []);
+  const applied = useSelector((store) => store.user.applied);
+
   const posts = useSelector((store) => store.posts.posts);
   const [lineHeight, setLineHeight] = useState(0);
   const ref = useRef();
@@ -29,7 +38,17 @@ function Home({ minHeight }) {
               🚣‍♂ 새로운 스터디를 모집해보세요!
             </InfoBox>
           ) : (
-            posts.map((post) => <Post key={post.postId} post={post} />)
+            posts.map((post) => {
+              let isApplied = false;
+              for (let i = 0; i < applied.length; i++) {
+                if (applied[i].postId === post.postId) {
+                  isApplied = true;
+                }
+              }
+              return (
+                <Post key={post.postId} post={post} isApplied={isApplied} />
+              );
+            })
           )}
         </PostList>
       </Content>

--- a/src/redux/modules/UserSlice.js
+++ b/src/redux/modules/UserSlice.js
@@ -1,17 +1,37 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import client from "../../api/client";
+
+export const __getAppliedStudies = createAsyncThunk(
+  "getAppliedStudies",
+  async (userId, thunkAPI) => {
+    try {
+      const { data } = await client.get(`/users/${userId}/apply`);
+      return thunkAPI.fulfillWithValue(data);
+    } catch (e) {
+      alert(`getAppliedStudiesError: ${e}`);
+    }
+  }
+);
 
 const initialState = {
   isLogin: false,
+  id: 0,
+  applied: [],
   isLoading: false,
 };
 
 const UserSlice = createSlice({
-  name: "User",
+  name: "user",
   initialState,
-  reducers: {
-    getUser: (state, payload) => {
-      console.log(state.posts, payload);
-    },
+  extraReducers: (builder) => {
+    builder
+      .addCase(__getAppliedStudies.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(__getAppliedStudies.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.applied = action.payload;
+      });
   },
 });
 


### PR DESCRIPTION
# 스터디 신청, 신청 취소, 상세 버튼 구현
## 변경 사항
* `src/components/`
  * `Post.js`: 
    1. 로그인 사용자가 해당 스터디를 신청했는지 여부를 props로 받아 `탑승하기`(=신청) , `하차하기` (=신청 취소) 버튼을 조건에 따라 보여줌. 
    2. `탑승하기` 버튼은 스터디의 모집인원과 신청인원 수가 같은 경우 disabled
    3. `구경하기`(=상세) 버튼 구현. 
* `src/pages/`
  * `Home.js`: 처음 랜더링 시, 로그인하면서 저장된 user의 id 값으로 신청한 스터디 목록 조회. 조회한 스터디 목록으로 각 스터디마다 사용자의 신청 여부를 확인하여 `isApplied` props를 전달.
* `src/redux/modules/`
  * `UserSlice.js`: 사용자의 스터디 목록 조회 thunk, reducer 구현.
