### PR TITLE
fix client to adjust server's header config

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -2,4 +2,14 @@ import axios from "axios";
 
 const client = axios.create({ baseURL: process.env.REACT_APP_API });
 
+export const nonTokenClient = axios.create({
+  baseURL: process.env.REACT_APP_API,
+});
+
+client.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem("accessToken");
+  config.headers["token"] = `${accessToken}`;
+  return config;
+});
+
 export default client;


### PR DESCRIPTION
#  fix client to adjust server's header config
## 구현 상세
* `src/api/` 
   * ` client.js`: 
     * token을 사용하지 않고 요청을 보내는 경우에 사용하는 axios instance로 `nonTokenClient` 추가.  
     * token을 사용하여 요청을 보내는 경우, axios instance에서 제공되는 `interceptor`를 사용하여 `config.headers`에 localStorage에 저장된 accessToken을 담아 보내도록 구현. 이 때 header에 담아 보내는 token의 저장 필드는 서버에서 지정한 필드명과 통일. 현재 프로젝트는 `token`을 필드로 함.
