### PR TITLE
fix promotion component to use actual api

### DIFF
--- a/src/components/Login/Promotion.js
+++ b/src/components/Login/Promotion.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, memo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
@@ -6,11 +6,11 @@ import Post from "../Post";
 
 import { __getPostsStatics } from "../../redux/modules/PostsSlice";
 
-function Promotion(props) {
-  //   const dispatch = useDispatch();
-  //   useEffect(() => {
-  //     dispatch(__getPostsStatics());
-  //   }, []);
+function Promotion() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(__getPostsStatics());
+  }, []);
   const totalPostsCount = useSelector((store) => store.posts.totalPostsCount);
   const completedPostsCount = useSelector(
     (store) => store.posts.completedPostsCount
@@ -85,4 +85,4 @@ const PostList = styled.div`
   }
 `;
 
-export default Promotion;
+export default memo(Promotion);

--- a/src/redux/modules/PostsSlice.js
+++ b/src/redux/modules/PostsSlice.js
@@ -1,13 +1,36 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import client from "../../api/client";
+import client, { nonTokenClient } from "../../api/client";
+
+export const __getPostsStatics = createAsyncThunk(
+  "getPostsStatics",
+  async (payload, thunkAPI) => {
+    try {
+      const { data } = await nonTokenClient.get(`/posts/statics`);
+      return thunkAPI.fulfillWithValue(data.data);
+    } catch (e) {
+      alert(`getPostsStaticsError: ${e}`);
+    }
+  }
+);
+
+export const __getPosts = createAsyncThunk(
+  "getPosts",
+  async (payload, thunkAPI) => {
+    try {
+      const { data } = await client.get(`/posts`);
+      return thunkAPI.fulfillWithValue(data);
+    } catch (e) {
+      alert(`getPostsError: ${e}`);
+    }
+  }
+);
 
 export const __addPost = createAsyncThunk(
   "addPost",
   async (payload, thunkAPI) => {
     try {
-      const { data } = await client.post(`/posts`, payload);
-      console.log(data);
+      await client.post(`/posts`, payload);
       return thunkAPI.fulfillWithValue(payload);
     } catch (e) {
       alert(`addPostError: ${e}`);
@@ -16,6 +39,8 @@ export const __addPost = createAsyncThunk(
 );
 
 const initialState = {
+  totalPostsCount: 0,
+  completedPostsCount: 0,
   posts: [
     {
       postId: 1,
@@ -60,6 +85,22 @@ const postsSlice = createSlice({
   initialState,
   extraReducers: (builder) => {
     builder
+      .addCase(__getPostsStatics.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(__getPostsStatics.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.totalPostsCount = action.payload.totalPostsCount;
+        state.completedPostsCount = action.payload.completedPostsCount;
+        state.posts = action.payload.posts;
+      })
+      .addCase(__getPosts.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(__getPosts.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.posts = action.payload;
+      })
       .addCase(__addPost.pending, (state) => {
         state.isLoading = true;
       })


### PR DESCRIPTION
# `Promotion` component 에서 `getPostsStatics` 실제 API 사용하도록 수정
## 변경 전
`Promotion` 페이지에서 사용하는 등록된 스터디 통계 데이터를 서버의 api로 요청하지 않음.

## 변경 후
`Promotion` 페이지에서 사용하는 등록된 스터디 통계 데이터를 서버의 api로 받아서 사용.