### PR TITLE
add sign up component input validation to prevent exceptional sign up request

### DIFF
--- a/src/redux/modules/UserSlice.js
+++ b/src/redux/modules/UserSlice.js
@@ -35,6 +35,7 @@ export const __signUp = createAsyncThunk(
   async (payload, thunkAPI) => {
     try {
       const { data } = await nonTokenClient.post("/users/signup", payload);
+      alert("회원가입이 완료되었습니다");
       window.location.href = "/login";
       return thunkAPI.fulfillWithValue(data.data);
     } catch (error) {
@@ -75,9 +76,7 @@ const initialState = {
   isLogin: false,
   applied: [],
   isLoading: false,
-  isEmailChecked: false,
   isEmailDuplicated: false,
-  isNicknameChecked: false,
   isNicknameDuplicated: false,
 };
 
@@ -98,12 +97,10 @@ const UserSlice = createSlice({
       })
       .addCase(__emailCheck.fulfilled, (state) => {
         state.isLoading = false;
-        state.isEmailChecked = true;
         state.isEmailDuplicated = false;
       })
       .addCase(__emailCheck.rejected, (state) => {
         state.isLoading = false;
-        state.isEmailChecked = true;
         state.isEmailDuplicated = true;
       })
       .addCase(__nicknameCheck.pending, (state) => {
@@ -111,12 +108,10 @@ const UserSlice = createSlice({
       })
       .addCase(__nicknameCheck.fulfilled, (state) => {
         state.isLoading = false;
-        state.isNicknameChecked = true;
         state.isNicknameDuplicated = false;
       })
       .addCase(__nicknameCheck.rejected, (state) => {
         state.isLoading = false;
-        state.isNicknameChecked = true;
         state.isNicknameDuplicated = true;
       })
       .addCase(__signIn.pending, (state) => {


### PR DESCRIPTION
# `Signup` 컴포넌트에 input validation 기능 추가
## 변경 전
* 이메일, 닉네임 중복 검사 시에만 이메일, 닉네임의 입력 여부 확인.
* 이메일, 닉네임 중복 검사를 한번 실행한 후에는 데이터가 변경되어도 중복 검사 필요 여부를 확인하지 않음.
* 비밀번호 확인 입력 시 비밀번호 일치 여부를 알려주는 메세지가 없음.
* '가입하기' 버튼 클릭 시, 입력하지 않은 데이터, 중복 검사하지 않은 데이터를 확인하지 않음.

## 변경 후
* 이메일, 닉네임 중복 검사를 실행한 후, 데이터가 변경되면 중복 검사를 다시 하도록 강제.
* 비밀번호 확인 입력 시에 일치하지 않는 경우 에러 메세지를 보여줌.
* 이메일, 닉네임 중복 검사, 비밀번호 재입력 검사를 통과하지 못한 경우에는 '가입하기' 버튼을 비활성화.