### PR TITLE
add logout handler

### DIFF
--- a/src/redux/modules/UserSlice.js
+++ b/src/redux/modules/UserSlice.js
@@ -7,7 +7,7 @@ export const __emailCheck = createAsyncThunk(
   async (payload, thunkAPI) => {
     try {
       const { data } = await nonTokenClient.get(
-        `/users/signup/emailNnickname?email=${payload.Email}&nickname=${""}`
+        `/users/signup/emailNnickname?email=${payload.email}&nickname=${""}`
       );
       return thunkAPI.fulfillWithValue(data);
     } catch (error) {
@@ -21,7 +21,7 @@ export const __nicknameCheck = createAsyncThunk(
   async (payload, thunkAPI) => {
     try {
       const { data } = await nonTokenClient.get(
-        `/users/signup/emailNnickname?email=${""}&nickname=${payload.Name}`
+        `/users/signup/emailNnickname?email=${""}&nickname=${payload.name}`
       );
       return thunkAPI.fulfillWithValue(data);
     } catch (error) {
@@ -80,9 +80,15 @@ const initialState = {
   isNicknameDuplicated: false,
 };
 
-const UserSlice = createSlice({
+const userSlice = createSlice({
   name: "user",
   initialState,
+  reducers: {
+    logout: (state) => {
+      localStorage.removeItem("accessToken");
+      state.isLogin = false;
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(__getAppliedStudies.pending, (state) => {
@@ -117,15 +123,16 @@ const UserSlice = createSlice({
       .addCase(__signIn.pending, (state) => {
         state.isLoading = true;
       })
-      .addCase(__signIn.fulfilled, (state, action) => {
+      .addCase(__signIn.fulfilled, (state) => {
         state.isLoading = false;
         state.isLogin = true;
       })
-      .addCase(__signIn.rejected, (state, action) => {
+      .addCase(__signIn.rejected, (state) => {
         state.isLoading = false;
         state.isLogin = false;
       });
   },
 });
 
-export default UserSlice.reducer;
+export const { logout } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/shared/Layout.js
+++ b/src/shared/Layout.js
@@ -1,7 +1,9 @@
 import React from "react";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 
 import Button from "../components/Button";
+import { logout } from "../redux/modules/UserSlice";
 
 const Header = styled.div`
   padding: 40px;
@@ -29,6 +31,12 @@ const Body = styled.div`
 `;
 
 const Layout = React.forwardRef((props, ref) => {
+  const dispatch = useDispatch();
+  const handleLogout = () => {
+    dispatch(logout());
+    window.location.replace("/login");
+  };
+
   if (window.location.pathname !== "/login") {
     return (
       <>
@@ -36,7 +44,7 @@ const Layout = React.forwardRef((props, ref) => {
           <Logo onClick={() => window.location.replace("/")}>🛶 Onpiece</Logo>
           <div>
             <WelcomeMsg>유진님 환영합니다.</WelcomeMsg>
-            <Button type="accent" text={`LOGOUT`} />
+            <Button type="accent" text={`LOGOUT`} handler={handleLogout} />
           </div>
         </Header>
         <Body>{props.children}</Body>


### PR DESCRIPTION
# 로그아웃 기능 구현
## 구현 상세
* `src/shared/`
  * `Layout.js`: 로그인 후 보이는 페이지 헤더의 로그아웃 버튼에 다음 세가지 동작을 실행하는 로그아웃 기능 구현.
    * `localStorage`의 `accessToken`을 삭제
    * `userSlice`의 `isLogin` 상태를 `false`로 변경
    * 브라우저의 경로를 `/login`으로 변경