### PR TITLE
fix login to save user id info on local storage

### DIFF
--- a/src/components/Login/Signup.js
+++ b/src/components/Login/Signup.js
@@ -11,6 +11,7 @@ import {
   __nicknameCheck,
   __signUp,
 } from "../../redux/modules/UserSlice";
+import { useNavigate } from "react-router-dom";
 
 function Signup({ handleChangeForm }) {
   const dispatch = useDispatch();
@@ -69,6 +70,7 @@ function Signup({ handleChangeForm }) {
     onChangePasswordCheck(e);
   };
 
+  const navigate = useNavigate();
   const handleSubmit = () => {
     let data = {
       email: email,
@@ -79,6 +81,7 @@ function Signup({ handleChangeForm }) {
     };
 
     dispatch(__signUp(data));
+    navigate("/login");
   };
   return (
     <Wrapper>

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -1,12 +1,12 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import Tag from "./Tag";
 import Progressbar from "./Progressbar";
-import dateTimeParser from "../tools/dateTimeParser";
-import { useNavigate } from "react-router-dom";
 import Button from "./Button";
-import { useSelector } from "react-redux";
+import dateTimeParser from "../tools/dateTimeParser";
 
 function Post({ width = 18, post, isApplied = false, isPublisher = false }) {
   const navigate = useNavigate();

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -1,5 +1,6 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import Button from "../components/Button";
@@ -8,9 +9,28 @@ import Tag from "../components/Tag";
 import dateTimeParser from "../tools/dateTimeParser";
 import CommentList from "../components/CommentList";
 
+import { __deletePost, __getPost } from "../redux/modules/PostsSlice";
+
 function Detail({ minHeight }) {
+  const { id } = useParams();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const handleGetPost = () => {
+    try {
+      dispatch(__getPost(id));
+    } catch (e) {
+      navigate("/");
+    }
+  };
+  useEffect(() => {
+    handleGetPost();
+  }, []);
+  const isLoading = useSelector((store) => store.posts.isLoading);
   const post = useSelector((store) => store.posts.post);
-  const userId = useSelector((store) => store.user.id);
+  const userInfo = useSelector((store) => store.user.userInfo);
+  const userId = !userInfo?.userId
+    ? localStorage.getItem("userId")
+    : userInfo.userId;
 
   const levelMsg = () => {
     switch (post.level) {
@@ -39,87 +59,110 @@ function Detail({ minHeight }) {
     else return `잘못된 percentage 정보입니다.`;
   };
 
+  const handleEdit = () => {
+    navigate(`/post/edit/${id}`);
+  };
+
+  const handleDelete = () => {
+    dispatch(__deletePost(id));
+    navigate(`/`);
+  };
+
   return (
     <Wrapper minHeight={`${minHeight}px`}>
       <Content>
         <ContentHeader>
           <PageTitle>스터디 구경하기</PageTitle>
         </ContentHeader>
-        <TopContent>
-          <TitleWrapper>
-            <TextWrapper>
-              <ContentTitle>{post.title}</ContentTitle>
-              <span>{`${dateTimeParser(
-                post.recruitmentEndDay
-              )} 까지 모집`}</span>
-            </TextWrapper>
-            <BtnWrapper show={post.userId === userId}>
-              <Button type="default" text="수정하기" />
-              <Button type="accent" text="삭제하기" />
-            </BtnWrapper>
-          </TitleWrapper>
-          <ProgressInfoWrapper>
-            <ProgressbarWrapper>
-              <Progressbar
-                width={50}
-                denominator={post.headCount}
-                numerator={post.applicants.length}
-              ></Progressbar>
-              <ProgressInfoText>
-                {ProgressMsg(
-                  Math.trunc((post.applicants.length / post.headCount) * 100)
-                )}
-              </ProgressInfoText>
-            </ProgressbarWrapper>
-            <Button text="탑승하기" disabled={post.userId === userId} />
-          </ProgressInfoWrapper>
-        </TopContent>
-        <TagBoxWrapper>
-          <TagBox>
-            <Tag type="level" text={post.level} />
-            <div>{levelMsg(post.level)}</div>
-          </TagBox>
-          <TagBox>
-            {post.category.map((v) => (
-              <Tag key={v} type="category" text={v} />
-            ))}
-          </TagBox>
-        </TagBoxWrapper>
-        <Label>스터디 안내</Label>
-        <BottomContent>
-          <LeftContent>
-            <TextBoxWrapper>
-              <TextBox>{post.content}</TextBox>
-            </TextBoxWrapper>
-          </LeftContent>
-          <RightContent>
-            <DescriptionBox>
-              <Label>{`👨‍✈ ${post.nickname} 선장님의 자기 소개`}</Label>
-              <div>{post.userDescription}</div>
-              <Label>📜 {`${post.nickname} 선장님이 이끌었던 스터디`}</Label>
-              <StudyTitleBoxWrapper>
-                {post.exPosts.map((v) => (
-                  <StudyTitleBox key={v}>{v}</StudyTitleBox>
+        {isLoading ? (
+          <LoadingMsg>데이터를 불러오는 중입니다.</LoadingMsg>
+        ) : (
+          <>
+            <TopContent>
+              <TitleWrapper>
+                <TextWrapper>
+                  <ContentTitle>{post.title}</ContentTitle>
+                  <span>{`${dateTimeParser(
+                    post.recruitmentEndDay
+                  )} 까지 모집`}</span>
+                </TextWrapper>
+                <BtnWrapper show={post.userId === userId}>
+                  <Button type="default" text="수정하기" handler={handleEdit} />
+                  <Button
+                    type="accent"
+                    text="삭제하기"
+                    handler={handleDelete}
+                  />
+                </BtnWrapper>
+              </TitleWrapper>
+              <ProgressInfoWrapper>
+                <ProgressbarWrapper>
+                  <Progressbar
+                    width={50}
+                    denominator={post.headCount}
+                    numerator={post.applicants.length}
+                  ></Progressbar>
+                  <ProgressInfoText>
+                    {ProgressMsg(
+                      Math.trunc(
+                        (post.applicants.length / post.headCount) * 100
+                      )
+                    )}
+                  </ProgressInfoText>
+                </ProgressbarWrapper>
+                <Button text="탑승하기" disabled={post.userId === userId} />
+              </ProgressInfoWrapper>
+            </TopContent>
+            <TagBoxWrapper>
+              <TagBox>
+                <Tag type="level" text={post.level} />
+                <div>{levelMsg(post.level)}</div>
+              </TagBox>
+              <TagBox>
+                {post.category.map((v) => (
+                  <Tag key={v} type="category" text={v} />
                 ))}
-              </StudyTitleBoxWrapper>
-            </DescriptionBox>
-            <InfoBoxWrapper>
-              <InfoBox>
-                <InfoLabel>스터디기간</InfoLabel>
-                <Info>
-                  {post.startDay} - {post.endDay}
-                </Info>
-              </InfoBox>
-              <InfoBox>
-                <InfoLabel>스터디시간</InfoLabel>
-                <Info>
-                  {post.startTime} - {post.endTime}
-                </Info>
-              </InfoBox>
-            </InfoBoxWrapper>
-          </RightContent>
-        </BottomContent>
-        <CommentList postId={post.postId} />
+              </TagBox>
+            </TagBoxWrapper>
+            <Label>스터디 안내</Label>
+            <BottomContent>
+              <LeftContent>
+                <TextBoxWrapper>
+                  <TextBox>{post.content}</TextBox>
+                </TextBoxWrapper>
+              </LeftContent>
+              <RightContent>
+                <DescriptionBox>
+                  <Label>{`👨‍✈ ${post.nickname} 선장님의 자기 소개`}</Label>
+                  <div>{post.userDescription}</div>
+                  <Label>
+                    📜 {`${post.nickname} 선장님이 이끌었던 스터디`}
+                  </Label>
+                  <StudyTitleBoxWrapper>
+                    {post.exPosts.map((v) => (
+                      <StudyTitleBox key={v}>{v}</StudyTitleBox>
+                    ))}
+                  </StudyTitleBoxWrapper>
+                </DescriptionBox>
+                <InfoBoxWrapper>
+                  <InfoBox>
+                    <InfoLabel>스터디기간</InfoLabel>
+                    <Info>
+                      {post.startDay} - {post.endDay}
+                    </Info>
+                  </InfoBox>
+                  <InfoBox>
+                    <InfoLabel>스터디시간</InfoLabel>
+                    <Info>
+                      {post.startTime} - {post.endTime}
+                    </Info>
+                  </InfoBox>
+                </InfoBoxWrapper>
+              </RightContent>
+            </BottomContent>
+            <CommentList postId={id} />
+          </>
+        )}
       </Content>
     </Wrapper>
   );
@@ -145,6 +188,15 @@ const ContentHeader = styled.div`
 const PageTitle = styled.h1`
   font-size: 20px;
   font-weight: 600;
+`;
+
+const LoadingMsg = styled.div`
+  width: 100%;
+  height: 50vh;
+  line-height: 50vh;
+  text-align: center;
+  color: white;
+  font-weight: 800;
 `;
 
 const TopContent = styled.div`

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,8 +10,12 @@ import { __getPosts } from "../redux/modules/PostsSlice";
 import { __getAppliedStudies } from "../redux/modules/UserSlice";
 
 function Home({ minHeight }) {
-  const userId = useSelector((store) => store.user.id);
   const dispatch = useDispatch();
+  const userInfo = useSelector((store) => store.user.userInfo);
+  const userId = !userInfo?.userId
+    ? localStorage.getItem("userId")
+    : userInfo.userId;
+
   useEffect(() => {
     dispatch(__getPosts());
     dispatch(__getAppliedStudies(userId));

--- a/src/redux/modules/PostsSlice.js
+++ b/src/redux/modules/PostsSlice.js
@@ -26,14 +26,38 @@ export const __getPosts = createAsyncThunk(
   }
 );
 
+export const __getPost = createAsyncThunk(
+  "getPost",
+  async (payload, thunkAPI) => {
+    try {
+      const { data } = await client.get(`/posts/${payload}`);
+      return thunkAPI.fulfillWithValue(data);
+    } catch (e) {
+      thunkAPI.rejectWithValue(e);
+    }
+  }
+);
+
 export const __addPost = createAsyncThunk(
   "addPost",
   async (payload, thunkAPI) => {
     try {
-      await client.post(`/posts`, payload);
-      return thunkAPI.fulfillWithValue(payload);
+      const { data } = await client.post(`/posts`, payload);
+      return thunkAPI.fulfillWithValue(data);
     } catch (e) {
       alert(`addPostError: ${e}`);
+    }
+  }
+);
+
+export const __deletePost = createAsyncThunk(
+  "deletePost",
+  async (payload, thunkAPI) => {
+    try {
+      await client.delete(`/posts/${payload.postId}`);
+      return thunkAPI.fulfillWithValue(payload);
+    } catch (e) {
+      alert(`deletePostError: ${e}`);
     }
   }
 );
@@ -104,12 +128,32 @@ const postsSlice = createSlice({
       .addCase(__getPosts.rejected, (state, action) => {
         alert(action.payload);
       })
+      .addCase(__getPost.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(__getPost.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.post = action.payload;
+      })
+      .addCase(__getPost.rejected, (state, action) => {
+        alert(action.payload);
+      })
       .addCase(__addPost.pending, (state) => {
         state.isLoading = true;
       })
       .addCase(__addPost.fulfilled, (state, action) => {
         state.isLoading = false;
         state.posts = [...state.posts, action.payload];
+      })
+      .addCase(__deletePost.pending, (state, action) => {
+        state.isLoading = true;
+      })
+      .addCase(__deletePost.fulfilled, (state, action) => {
+        state.isLoading = false;
+        const posts = [...state.posts];
+        state.posts = posts.filter(
+          (post) => post.postId !== action.payload.postId
+        );
       });
   },
 });

--- a/src/shared/Header.js
+++ b/src/shared/Header.js
@@ -1,13 +1,20 @@
-import React from "react";
-import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { useNavigate, Link } from "react-router-dom";
 import styled from "styled-components";
 
 import Button from "../components/Button";
-import { logout } from "../redux/modules/UserSlice";
+import { logout, __getUserInfo } from "../redux/modules/UserSlice";
 
-const Header = React.forwardRef(({ show }, ref) => {
+const Header = React.forwardRef((props, ref) => {
   const dispatch = useDispatch();
+  const userInfo = useSelector((store) => store.user.userInfo);
+  const userId = !userInfo?.userId
+    ? localStorage.getItem("userId")
+    : userInfo.userId;
+  useEffect(() => {
+    if (!userInfo?.nickname) dispatch(__getUserInfo(userId));
+  }, []);
   const navigate = useNavigate();
   const handleLogout = () => {
     dispatch(logout());
@@ -15,10 +22,12 @@ const Header = React.forwardRef(({ show }, ref) => {
   };
 
   return (
-    <Wrapper ref={ref} show={show}>
+    <Wrapper ref={ref}>
       <Logo onClick={() => navigate("/")}>🛶 Onpiece</Logo>
       <div>
-        <WelcomeMsg>유진님 환영합니다.</WelcomeMsg>
+        <WelcomeMsg>
+          <Link to={`/user/${userId}`}>{userInfo?.nickname}</Link>님 환영합니다.
+        </WelcomeMsg>
         <Button type="accent" text={`LOGOUT`} handler={handleLogout} />
       </div>
     </Wrapper>
@@ -27,7 +36,7 @@ const Header = React.forwardRef(({ show }, ref) => {
 
 const Wrapper = styled.div`
   padding: 40px;
-  display: ${(props) => (props.show ? "flex" : "none")};
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;

--- a/src/shared/Routes.js
+++ b/src/shared/Routes.js
@@ -22,12 +22,13 @@ const Router = () => {
 
   return (
     <BrowserRouter>
-      <Header ref={ref} show={isLogin} />
+      {isLogin ? <Header ref={ref} /> : <></>}
       <Routes>
         <Route path="/" element={<Home minHeight={bodyHeight} />} />
         <Route path="/login" element={<Login />} />
         <Route path="/post/:id" element={<Detail minHeight={bodyHeight} />} />
         <Route path="/post" element={<PostCreate />} />
+        <Route path="/user/:id" element={<User />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
# `Login` 시에 `userId`, `nickname` 정보를 저장하도록 수정
## 변경 전
메인 페이지에서 `useId`를 통해 `Header` 컴포넌트에서 사용하는 `nickname` 정보 및 사용자가 신청 완료한 강의 정보를 불러오는데, 로그인 시에는 해당 정보를 제공하지 않음.
따라서 로그인 후, 메인 페이지 랜더링 시에 `getUserInfo` 요청을 통해 받은 정보를 사용해야함.
그러나 해당 정보를 받는 시점을 예측할 수 없기 때문에 하나의 로직으로 메인페이지 랜더링이 구현되어야 함.

## 변경 후
로그인 시에 `userId`, `nickname`정보를 받아 사용하고, `userId`는 `accessToken`과 마찬가지로 localStorage에 저장해두어서 만료 혹은 로그아웃 전까지 페이지 리로드에 상관없이 사용할 수 있음. 페이지 리로드로 인해 store의 `userInfo` 상태가 초기화 되었다면 localStorage에 저장된 `userId` 정보로 `getUserInfo` 요청을 함.