### PR TITLE
fix comment to check comment writer's user id with login user's user id

### DIFF
--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -13,7 +13,11 @@ import { useDispatch, useSelector } from "react-redux";
 function Comment({
   comment: { commentId, userId, nickname, comment, updatedAt },
 }) {
-  const loginUserId = useSelector((store) => store.user.id);
+  const userInfo = useSelector((store) => store.user.userInfo);
+  const loginUserId = !userInfo?.userId
+    ? localStorage.getItem("userId")
+    : userInfo.userId;
+
   const dispatch = useDispatch();
   const ref = useRef();
   const [isModify, setIsModify] = useState(false);

--- a/src/components/CommentList.js
+++ b/src/components/CommentList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, memo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 
@@ -79,4 +79,4 @@ const InfoBox = styled.div`
   font-size: 12px;
 `;
 
-export default CommentList;
+export default memo(CommentList);


### PR DESCRIPTION
# `Comment` 컴포넌트에서 댓글 작성자 여부를 확인하는 user id 정보 가져오는 부분 수정
## 변경 전
`user` slice의 `userInfo` 속성 내에 `userId` 정보가 저장되는 방식으로 수정되었지만, `user` slice의 `id` 속성을 읽어옴.

## 변경 후
변경된 `user` slice에 맞춰 `loginUserId` 정보를 제대로 읽어와 작성자 여부를 확인함.
