### PR TITLE
fix post CRUD bugs

### DIFF
--- a/src/components/PostForm.js
+++ b/src/components/PostForm.js
@@ -12,7 +12,7 @@ import {
   unixLocalTimeConverter,
 } from "../tools/timeConverter";
 
-import { __addPost } from "../redux/modules/PostsSlice";
+import { __addPost, __updatePost } from "../redux/modules/PostsSlice";
 
 function PostForm({
   post: {
@@ -27,6 +27,7 @@ function PostForm({
     startDay = "0000-00-00",
     endDay = "0000-00-00",
   },
+  type,
 }) {
   const dispatch = useDispatch();
   const titleRef = useRef();
@@ -157,8 +158,16 @@ function PostForm({
       endDay: studyEndDate,
     };
 
-    dispatch(__addPost(post));
-    navigate("/");
+    switch (type) {
+      case "add":
+        dispatch(__addPost(post));
+        navigate("/");
+        return;
+      case "edit":
+        dispatch(__updatePost(post));
+        navigate("/");
+        return;
+    }
   };
 
   return (

--- a/src/pages/PostCreate.js
+++ b/src/pages/PostCreate.js
@@ -29,7 +29,7 @@ function PostCreate() {
         <ContentHeader>
           <PageTitle>스터디 모집하기</PageTitle>
         </ContentHeader>
-        <PostForm post={initialPost}></PostForm>
+        <PostForm post={initialPost} type="add"></PostForm>
       </Content>
     </Wrapper>
   );

--- a/src/pages/PostEdit.js
+++ b/src/pages/PostEdit.js
@@ -26,7 +26,7 @@ function PostEdit() {
         <ContentHeader>
           <PageTitle>스터디 수정하기</PageTitle>
         </ContentHeader>
-        <PostForm post={initialPost}></PostForm>
+        <PostForm post={initialPost} type="edit"></PostForm>
       </Content>
     </Wrapper>
   );

--- a/src/redux/modules/PostsSlice.js
+++ b/src/redux/modules/PostsSlice.js
@@ -43,9 +43,21 @@ export const __addPost = createAsyncThunk(
   async (payload, thunkAPI) => {
     try {
       const { data } = await client.post(`/posts`, payload);
-      return thunkAPI.fulfillWithValue(data);
+      return thunkAPI.fulfillWithValue(data.createdPost);
     } catch (e) {
       alert(`addPostError: ${e}`);
+    }
+  }
+);
+
+export const __updatePost = createAsyncThunk(
+  "updatePost",
+  async (payload, thunkAPI) => {
+    try {
+      const { data } = await client.put(`/posts/${payload.postId}`, payload);
+      return thunkAPI.fulfillWithValue(data);
+    } catch (e) {
+      alert(`updatePostError: ${e}`);
     }
   }
 );
@@ -54,7 +66,7 @@ export const __deletePost = createAsyncThunk(
   "deletePost",
   async (payload, thunkAPI) => {
     try {
-      await client.delete(`/posts/${payload.postId}`);
+      await client.delete(`/posts/${payload}`);
       return thunkAPI.fulfillWithValue(payload);
     } catch (e) {
       alert(`deletePostError: ${e}`);
@@ -149,15 +161,27 @@ const postsSlice = createSlice({
         state.isLoading = false;
         state.posts = [...state.posts, action.payload];
       })
-      .addCase(__deletePost.pending, (state, action) => {
+      .addCase(__updatePost.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(__updatePost.fulfilled, (state, action) => {
+        state.isLoading = false;
+        const posts = [...state.posts];
+        state.posts = posts.map((post) => {
+          if (post.postId === action.payload.postId) {
+            return action.payload;
+          }
+
+          return post;
+        });
+      })
+      .addCase(__deletePost.pending, (state) => {
         state.isLoading = true;
       })
       .addCase(__deletePost.fulfilled, (state, action) => {
         state.isLoading = false;
         const posts = [...state.posts];
-        state.posts = posts.filter(
-          (post) => post.postId !== action.payload.postId
-        );
+        state.posts = posts.filter((post) => post.postId !== action.payload);
       });
   },
 });


### PR DESCRIPTION
# post 관련 CRUD 버그 수정
## 변경 전
* `addPost` 시에 200 response와 함께 받은 Post 데이터가 store에 제대로 저장 안됨.
  * 원인: `data.createdPost`에 Post 데이터가 담겨 있음.
* `addPost` 후 `Home` 페이지로 이동하지 않음.
* `updatePost` 기능 구현 안됨
* `deletePost` 시에 store의 posts에 삭제된 내용이 제대로 반영되지 않음.
  * 원인: `payload` 에 `postId` 속성이 아니라 `payload` 자체가 `postId` 정보만 담고 있음. 

## 변경 후
* `addPost` 시에 200 response와 함께 받은 Post 데이터가 store에 반영됨.
* `addPost` 완료 후 `Home` 페이지로 이동.
* `updatePost` 기능 구현.
* `deletePost` 시에 store의 posts에서 삭제한 post 제거됨.