### PR TITLE
fix update post thunk to get id as params

### DIFF
--- a/src/components/PostForm.js
+++ b/src/components/PostForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import Button from "./Button";
@@ -68,6 +68,8 @@ function PostForm({
     setStudyStartDate(startDay);
     setStudyEndDate(endDay);
   };
+
+  const { id } = useParams();
 
   const handleSelect = ({ target: { value } }) => {
     for (let i = 0; i < selectedOptions.length; i++) {
@@ -164,7 +166,7 @@ function PostForm({
         navigate("/");
         return;
       case "edit":
-        dispatch(__updatePost(post));
+        dispatch(__updatePost({ id, post }));
         navigate("/");
         return;
     }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -19,7 +19,7 @@ function Home({ minHeight }) {
   useEffect(() => {
     dispatch(__getPosts());
     dispatch(__getAppliedStudies(userId));
-  }, []);
+  }, [dispatch]);
   const applied = useSelector((store) => store.user.applied);
 
   const posts = useSelector((store) => store.posts.posts);

--- a/src/redux/modules/PostsSlice.js
+++ b/src/redux/modules/PostsSlice.js
@@ -54,7 +54,7 @@ export const __updatePost = createAsyncThunk(
   "updatePost",
   async (payload, thunkAPI) => {
     try {
-      const { data } = await client.put(`/posts/${payload.postId}`, payload);
+      const { data } = await client.put(`/posts/${payload.id}`, payload.post);
       return thunkAPI.fulfillWithValue(data);
     } catch (e) {
       alert(`updatePostError: ${e}`);


### PR DESCRIPTION
# posts slice 관련 버그 수정
## 변경 전
* `updatePost` 시  axios 요청 url의 `postId`값이 `undefined` 로 나옴.
  * 원인: post데이터에 postId가 없었기에 생긴문제
* 메인 페이지로 이동시 리랜더링이 안됨. 
  *원인: `Home.js`의 useEffect에 의존성배열이 비어있음

## 변경 후
* `updatePost` 시에 `PostForm.js` 에서 생성된 params로 id를 가져와 제대로 된 url로 요청이 감
* `Home.js` 의 의존성배열안에 dispatch를 넣어줘 메인페이지가 제대로 렌더링됨